### PR TITLE
Account object refactor

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,7 +77,7 @@ jobs:
           flutter build apk;
 
   ios:
-    runs-on: macos-11
+    runs-on: macos-14-xlarge
     timeout-minutes: 25
     steps:
       - name: 'Checkout Repo'
@@ -132,7 +132,7 @@ jobs:
       - name: 'Set Xcode version'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '13.1'
+          xcode-version: '16.2.0'
 
       - name: 'Install Dart dependencies'
         if: steps.pub-cache.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,14 +31,14 @@ jobs:
 
       - name: 'Cache Flutter'
         id: flutter-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.OS }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
           path: /opt/hostedtoolcache/flutter
 
       - name: 'Cache Flutter dependencies'
         id: pub-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
           path: |
@@ -87,14 +87,14 @@ jobs:
 
       - name: 'Cache Flutter'
         id: flutter-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.OS }}-flutter-install-cache-${{ env.FLUTTER_VERSION }}
           path: /Users/runner/hostedtoolcache/flutter
 
       - name: 'Cache Flutter dependencies'
         id: pub-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
           path: |
@@ -106,14 +106,14 @@ jobs:
 
       - name: 'Cache Ruby dependencies'
         id: ruby-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
           path: ${{ github.workspace }}/vendor/bundle
 
       - name: 'Cache Pods'
         id: pod-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           path: ${{ github.workspace }}/example/ios/Pods

--- a/lib/mobilecoin_flutter.dart
+++ b/lib/mobilecoin_flutter.dart
@@ -4,7 +4,7 @@ export 'package:mobilecoin_flutter/src/account_key.dart';
 export 'package:mobilecoin_flutter/src/attestation/client_config.dart';
 export 'package:mobilecoin_flutter/src/attestation/service_config.dart';
 export 'package:mobilecoin_flutter/src/mobilecoin_client.dart';
-export 'package:mobilecoin_flutter/src/mobilecoin_flutter_plugin_channel_api.dart';
+export 'package:mobilecoin_flutter/src/mobilecoin_config.dart';
 export 'package:mobilecoin_flutter/src/printable_wrapper.dart';
 export 'package:mobilecoin_flutter/src/protobufs/generated/mistyswap_common.pb.dart'
     show GetInfoResponse;

--- a/lib/src/account_key.dart
+++ b/lib/src/account_key.dart
@@ -7,18 +7,19 @@ import 'package:mobilecoin_flutter/src/platform_object.dart';
 import 'package:mobilecoin_flutter/src/public_address.dart';
 
 class AccountKey extends PlatformObject {
-  PublicAddress? _publicAddress;
-  Uint8List bip39Entropy;
-  Uint8List fogAuthoritySpki;
-  String fogReportUri;
-  String reportId;
+  final PublicAddress publicAddress;
+  final Uint8List bip39Entropy;
+  final Uint8List fogAuthoritySpki;
+  final String fogReportUri;
+  final String reportId;
 
-  AccountKey(
+  const AccountKey(
     int objectId,
     this.bip39Entropy,
     this.fogReportUri,
     this.fogAuthoritySpki,
     this.reportId,
+    this.publicAddress,
   ) : super(id: objectId);
 
   static Future<AccountKey> fromBip39Entropy(
@@ -27,28 +28,23 @@ class AccountKey extends PlatformObject {
     required Uint8List fogAuthoritySpki,
     required String reportId,
   }) async {
-    final objectId = await MobileCoinFlutterPluginChannelApi.instance
+    final accountObjectId = await MobileCoinFlutterPluginChannelApi.instance
         .getAccountKeyFromBip39Entropy(
       entropy: entropy,
       fogReportUri: fogReportUri,
       fogAuthoritySpki: fogAuthoritySpki,
       reportId: reportId,
     );
+    final publicKeyObjectId = await MobileCoinFlutterPluginChannelApi.instance
+        .getAccountKeyPublicAddress(accountKeyId: accountObjectId);
+
     return AccountKey(
-      objectId,
+      accountObjectId,
       entropy,
       fogReportUri,
       fogAuthoritySpki,
       reportId,
+      PublicAddress(publicKeyObjectId),
     );
-  }
-
-  Future<PublicAddress> getPublicAddress() async {
-    if (null == _publicAddress) {
-      final objectId = await MobileCoinFlutterPluginChannelApi.instance
-          .getAccountKeyPublicAddress(accountKeyId: id);
-      _publicAddress = PublicAddress(objectId);
-    }
-    return _publicAddress!;
   }
 }

--- a/lib/src/account_key.dart
+++ b/lib/src/account_key.dart
@@ -2,12 +2,11 @@
 
 import 'dart:typed_data';
 
-import 'package:mobilecoin_flutter/src/mobilecoin_flutter_plugin_channel_api.dart';
+import 'package:mobilecoin_flutter/mobilecoin_flutter.dart';
 import 'package:mobilecoin_flutter/src/platform_object.dart';
-import 'package:mobilecoin_flutter/src/public_address.dart';
 
 class AccountKey extends PlatformObject {
-  final PublicAddress publicAddress;
+  final String publicAddress;
   final Uint8List bip39Entropy;
   final Uint8List fogAuthoritySpki;
   final String fogReportUri;
@@ -38,13 +37,17 @@ class AccountKey extends PlatformObject {
     final publicKeyObjectId = await MobileCoinFlutterPluginChannelApi.instance
         .getAccountKeyPublicAddress(accountKeyId: accountObjectId);
 
+    final printableWrapper = await PrintableWrapper.fromPublicAddress(
+      PublicAddress(publicKeyObjectId),
+    );
+
     return AccountKey(
       accountObjectId,
       entropy,
       fogReportUri,
       fogAuthoritySpki,
       reportId,
-      PublicAddress(publicKeyObjectId),
+      await printableWrapper.toB58String(),
     );
   }
 }

--- a/lib/src/mobilecoin_client.dart
+++ b/lib/src/mobilecoin_client.dart
@@ -4,45 +4,76 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:mobilecoin_flutter/src/account_key.dart';
-import 'package:mobilecoin_flutter/src/attestation/client_config.dart';
 import 'package:mobilecoin_flutter/src/mobilecoin_flutter_plugin_channel_api.dart';
 import 'package:mobilecoin_flutter/src/platform_object.dart';
 import 'package:mobilecoin_flutter/src/public_address.dart';
 import 'package:mobilecoin_flutter/src/protobufs/generated/mistyswap_offramp.pb.dart';
 
 class MobileCoinFlutterClient extends PlatformObject {
-  final AccountKey accountKey;
+  MobileCoinFlutterClient(int objectId) : super(id: objectId);
 
-  MobileCoinFlutterClient(this.accountKey, int objectId) : super(id: objectId);
+  static Future<MobileCoinFlutterClient> create(AccountKey accountKey) async {
+    final objectId = await MobileCoinFlutterPluginChannelApi.instance
+        .createMobileCoinClient(accountKey);
 
-  static Future<MobileCoinFlutterClient> create(
-    AccountKey accountKey,
-    String fogUrl,
-    String consensusUrl,
-    bool useTestNet,
-    ClientConfig attestClientConfig, [
-    String? mistyswapUrl,
-  ]) async {
-    final objectId =
-        await MobileCoinFlutterPluginChannelApi.instance.createMobileCoinClient(
-      accountKey: accountKey,
-      fogUrl: fogUrl,
-      consensusUrl: consensusUrl,
-      useTestNet: useTestNet,
-      attestClientConfig: attestClientConfig,
-      mistyswapUrl: mistyswapUrl,
-    );
-    return MobileCoinFlutterClient(accountKey, objectId);
+    return MobileCoinFlutterClient(objectId);
   }
 
-  Future<Map<String, Object?>> createPendingTransaction(
-    PublicAddress recipient,
-    BigInt amount,
-    BigInt fee,
-    BigInt tokenId,
-    String rngSeed,
-    BigInt paymentRequestId,
-  ) async {
+  static Future<Uint8List> mnemonicToBip39Entropy(String mnemonicPhrase) =>
+      MobileCoinFlutterPluginChannelApi.instance
+          .mnemonicToBip39Entropy(mnemonicPhrase);
+
+  static Future<String> mnemonicAllWords() =>
+      MobileCoinFlutterPluginChannelApi.instance.mnemonicAllWords();
+
+  static Future<Uint8List> publicAddressGetAddressHash({
+    required int publicAddressId,
+  }) =>
+      MobileCoinFlutterPluginChannelApi.instance
+          .publicAddressGetAddressHash(publicAddressId: publicAddressId);
+
+  static Future<int> printableWrapperFromB58String({
+    required String b58String,
+  }) =>
+      MobileCoinFlutterPluginChannelApi.instance
+          .printableWrapperFromB58String(b58String: b58String);
+
+  static Future<int> paymentRequestCreate({
+    required PublicAddress publicAddress,
+    required BigInt tokenId,
+    String? memo,
+    BigInt? amount,
+  }) =>
+      MobileCoinFlutterPluginChannelApi.instance.paymentRequestCreate(
+        publicAddress: publicAddress,
+        tokenId: tokenId,
+        memo: memo,
+        amount: amount,
+      );
+
+  static Future<int> printableWrapperFromPaymentRequest({
+    required int paymentRequestId,
+  }) =>
+      MobileCoinFlutterPluginChannelApi.instance
+          .printableWrapperFromPaymentRequest(
+        paymentRequestId: paymentRequestId,
+      );
+
+  static Future<String> printableWrapperToB58String({
+    required int printableWrapperId,
+  }) =>
+      MobileCoinFlutterPluginChannelApi.instance.printableWrapperToB58String(
+        printableWrapperId: printableWrapperId,
+      );
+
+  Future<Map<String, Object?>> createPendingTransaction({
+    required PublicAddress recipient,
+    required BigInt amount,
+    required BigInt fee,
+    required BigInt tokenId,
+    required String rngSeed,
+    BigInt? paymentRequestId,
+  }) async {
     return await MobileCoinFlutterPluginChannelApi.instance
         .createPendingTransaction(
       mobileClientId: id,

--- a/lib/src/mobilecoin_config.dart
+++ b/lib/src/mobilecoin_config.dart
@@ -1,0 +1,23 @@
+import 'dart:typed_data';
+
+import 'package:mobilecoin_flutter/mobilecoin_flutter.dart';
+
+class MobileCoinConfig {
+  final String fogUrl;
+  final String consensusUrl;
+  final bool useTestNet;
+  final ClientConfig attestClientConfig;
+  final String mistyswapUrl;
+  final Uint8List fogAuthoritySpki;
+  final String fogReportId;
+
+  const MobileCoinConfig({
+    required this.fogUrl,
+    required this.consensusUrl,
+    required this.useTestNet,
+    required this.attestClientConfig,
+    required this.mistyswapUrl,
+    required this.fogAuthoritySpki,
+    required this.fogReportId,
+  });
+}

--- a/lib/src/mobilecoin_flutter_plugin_channel_api.dart
+++ b/lib/src/mobilecoin_flutter_plugin_channel_api.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:mobilecoin_flutter/src/account_key.dart';
-import 'package:mobilecoin_flutter/src/attestation/client_config.dart';
 import 'package:mobilecoin_flutter/src/attestation/service_config.dart';
 import 'package:mobilecoin_flutter/src/protobufs/generated/mistyswap_common.pb.dart';
 import 'package:mobilecoin_flutter/src/protobufs/generated/mistyswap_offramp.pb.dart';
@@ -28,22 +27,16 @@ class MobileCoinFlutterPluginChannelApi {
 
   final MethodChannel _channel;
 
-  Future<int> createMobileCoinClient({
-    required AccountKey accountKey,
-    required String fogUrl,
-    required String consensusUrl,
-    required bool useTestNet,
-    required ClientConfig attestClientConfig,
-    String? mistyswapUrl,
-  }) async {
+  Future<int> createMobileCoinClient(AccountKey key) async {
     final Map<String, dynamic> params = <String, dynamic>{
-      'accountKey': accountKey.id,
-      'fogUrl': fogUrl,
-      'consensusUrl': consensusUrl,
-      'mistyswapUrl': mistyswapUrl,
-      'useTestNet': useTestNet,
-      'clientConfigId': attestClientConfig.id,
+      'accountKey': key.id,
+      'fogUrl': key.config.fogUrl,
+      'consensusUrl': key.config.consensusUrl,
+      'mistyswapUrl': key.config.mistyswapUrl,
+      'useTestNet': key.config.useTestNet,
+      'clientConfigId': key.config.attestClientConfig.id,
     };
+
     return await _channel.invokeMethod("MobileCoinClient#create", params);
   }
 
@@ -150,14 +143,14 @@ class MobileCoinFlutterPluginChannelApi {
   Future<int> getAccountKeyFromBip39Entropy({
     required Uint8List entropy,
     required String fogReportUri,
-    required String reportId,
+    required String fogReportId,
     required Uint8List fogAuthoritySpki,
   }) async {
     final Map<String, dynamic> params = <String, dynamic>{
       'bip39Entropy': entropy,
       'fogReportUri': fogReportUri,
       'fogAuthoritySpki': fogAuthoritySpki,
-      'reportId': reportId,
+      'reportId': fogReportId,
     };
     return await _channel.invokeMethod("AccountKey#fromBip39Entropy", params);
   }

--- a/lib/src/mobilecoin_flutter_plugin_channel_api.dart
+++ b/lib/src/mobilecoin_flutter_plugin_channel_api.dart
@@ -42,7 +42,7 @@ class MobileCoinFlutterPluginChannelApi {
       'consensusUrl': consensusUrl,
       'mistyswapUrl': mistyswapUrl,
       'useTestNet': useTestNet,
-      'clientConfigId': attestClientConfig.id
+      'clientConfigId': attestClientConfig.id,
     };
     return await _channel.invokeMethod("MobileCoinClient#create", params);
   }

--- a/lib/src/platform_object.dart
+++ b/lib/src/platform_object.dart
@@ -3,7 +3,7 @@
 /// Represents a platform-side object, e.g., Android or iOS object, within
 /// Flutter code.
 abstract class PlatformObject {
-  PlatformObject({required this.id});
+  const PlatformObject({required this.id});
 
   /// The hashcode of this object on the platform side, e.g., Android or iOS.
   final int id;


### PR DESCRIPTION
Makes some improvements to the AccountKey object to include

- public address
- public address hash
- mnemonic phrase

so it doesn't take an extra query to access that data. 

Also, `MobileCoinFlutterPluginChannelApi` was publicly available and shouldn't be. So any functions necessary outside the api that don't require a client id have become static methods on `MobileCoinFlutterClient` for ease of migration.

`MobileCoinFlutterPluginChannelApi.instance` -> `MobileCoinFlutterClient`