### PR TITLE
Nullable misty swap url

### DIFF
--- a/lib/src/extensions/string_extensions.dart
+++ b/lib/src/extensions/string_extensions.dart
@@ -1,0 +1,5 @@
+extension NullableStringExtension on String? {
+  bool get isPresent => (this?.trim() ?? '') != '';
+
+  String? get presence => isPresent ? this : null;
+}

--- a/lib/src/mobilecoin_config.dart
+++ b/lib/src/mobilecoin_config.dart
@@ -7,7 +7,7 @@ class MobileCoinConfig {
   final String consensusUrl;
   final bool useTestNet;
   final ClientConfig attestClientConfig;
-  final String mistyswapUrl;
+  final String? mistyswapUrl;
   final Uint8List fogAuthoritySpki;
   final String fogReportId;
 

--- a/lib/src/mobilecoin_flutter_plugin_channel_api.dart
+++ b/lib/src/mobilecoin_flutter_plugin_channel_api.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:mobilecoin_flutter/src/account_key.dart';
 import 'package:mobilecoin_flutter/src/attestation/service_config.dart';
+import 'package:mobilecoin_flutter/src/extensions/string_extensions.dart';
 import 'package:mobilecoin_flutter/src/protobufs/generated/mistyswap_common.pb.dart';
 import 'package:mobilecoin_flutter/src/protobufs/generated/mistyswap_offramp.pb.dart';
 import 'package:mobilecoin_flutter/src/protobufs/generated/mistyswap_onramp.pb.dart';
@@ -32,7 +33,8 @@ class MobileCoinFlutterPluginChannelApi {
       'accountKey': key.id,
       'fogUrl': key.config.fogUrl,
       'consensusUrl': key.config.consensusUrl,
-      'mistyswapUrl': key.config.mistyswapUrl,
+      // mistyswapUrl can be null, but must not be an empty string
+      'mistyswapUrl': key.config.mistyswapUrl.presence,
       'useTestNet': key.config.useTestNet,
       'clientConfigId': key.config.attestClientConfig.id,
     };


### PR DESCRIPTION
If the sdks are given an empty string as the mistyswap url, they return an error. This PR allows it to be null and ensures it is not an empty string.