### PR TITLE
PaymentRequest payment_id

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 dependencies {
-    implementation 'com.mobilecoin:android-sdk:6.1.0'
+    implementation 'com.mobilecoin:android-sdk:6.1.3'
 }
 
 android {

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
@@ -16,7 +16,7 @@ public class FfiPaymentRequest {
 
     public static int create(int publicAddressId, @Nullable UnsignedLong amount,
                              @Nullable String memo, @NonNull TokenId tokenId,
-                             @Nullable String paymentId) {
+                             @Nullable UnsignedLong paymentId) {
         PublicAddress publicAddress = (PublicAddress) ObjectStorage.objectForKey(publicAddressId);
         if (memo == null) memo = "";
         if (amount == null) amount = UnsignedLong.ZERO;

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
@@ -49,4 +49,9 @@ public class FfiPaymentRequest {
         ObjectStorage.addObject(hashCode, publicAddress);
         return hashCode;
     }
+
+    public static String getPaymentId(int requestId) {
+        PaymentRequest paymentRequest = (PaymentRequest) ObjectStorage.objectForKey(requestId);
+        return paymentRequest.getPaymentId();
+    }
 }

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
@@ -52,6 +52,6 @@ public class FfiPaymentRequest {
 
     public static String getPaymentId(int requestId) {
         PaymentRequest paymentRequest = (PaymentRequest) ObjectStorage.objectForKey(requestId);
-        return paymentRequest.getPaymentId();
+        return paymentRequest.getPaymentId().toString();
     }
 }

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
@@ -15,11 +15,12 @@ import androidx.annotation.Nullable;
 public class FfiPaymentRequest {
 
     public static int create(int publicAddressId, @Nullable UnsignedLong amount,
-                             @Nullable String memo, @NonNull TokenId tokenId) {
+                             @Nullable String memo, @NonNull TokenId tokenId,
+                             @Nullable String paymentId) {
         PublicAddress publicAddress = (PublicAddress) ObjectStorage.objectForKey(publicAddressId);
         if (memo == null) memo = "";
         if (amount == null) amount = UnsignedLong.ZERO;
-        PaymentRequest paymentRequest = new PaymentRequest(publicAddress, amount, memo, tokenId);
+        PaymentRequest paymentRequest = new PaymentRequest(publicAddress, amount, memo, tokenId, paymentId);
         final int hashCode = paymentRequest.hashCode();
         ObjectStorage.addObject(hashCode, paymentRequest);
         return hashCode;

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
@@ -243,8 +243,14 @@ public class MobileCoinFlutterPlugin implements FlutterPlugin, MethodCallHandler
             case "PaymentRequest#create": {
                 BigInteger bigTokenId = new BigInteger((String) getCallArgument(call, "tokenId"));
                 TokenId tokenId = TokenId.from(UnsignedLong.fromBigInteger(bigTokenId));
+                UnsignedLong paymentId = null;
+                if (null != call.argument("paymentId")) {
+                    BigInteger bigPaymentId = new BigInteger((String) getCallArgument(call, "paymentId"));
+                    paymentId = UnsignedLong.fromBigInteger(bigPaymentId);
+                }
                 return api.paymentRequestCreate(getCallArgument(call, "publicAddressId"),
-                        getCallArgument(call, "amount"), getCallArgument(call, "memo"), tokenId);
+                        getCallArgument(call, "amount"), getCallArgument(call, "memo"),
+                        tokenId, paymentId);
             }
             case "PaymentRequest#getMemo":
                 return api.paymentRequestGetMemo(getCallArgument(call, "id"));

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
@@ -501,7 +501,7 @@ public class MobileCoinFlutterPlugin implements FlutterPlugin, MethodCallHandler
          * Creates a new <code>PaymentRequest</code> in local object storage, then returns its id.
          */
         int paymentRequestCreate(int publicAddressId, @Nullable String amount,
-                @Nullable String memo, @NonNull TokenId tokenId);
+                @Nullable String memo, @NonNull TokenId tokenId, @Nullable String paymentId);
 
         /**
          * Looks up the given <code>PaymentRequest</code> in local object storage, then returns its
@@ -832,10 +832,10 @@ public class MobileCoinFlutterPlugin implements FlutterPlugin, MethodCallHandler
 
         @Override
         public int paymentRequestCreate(int publicAddressId, @Nullable String amount,
-                @Nullable String memo, @NonNull TokenId tokenId) {
+                @Nullable String memo, @NonNull TokenId tokenId, @Nullable String paymentId) {
             UnsignedLong unsignedAmount =
                     amount == null ? null : UnsignedLong.fromBigInteger(new BigInteger(amount));
-            return FfiPaymentRequest.create(publicAddressId, unsignedAmount, memo, tokenId);
+            return FfiPaymentRequest.create(publicAddressId, unsignedAmount, memo, tokenId, paymentId);
         }
 
         @Override

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
@@ -501,7 +501,7 @@ public class MobileCoinFlutterPlugin implements FlutterPlugin, MethodCallHandler
          * Creates a new <code>PaymentRequest</code> in local object storage, then returns its id.
          */
         int paymentRequestCreate(int publicAddressId, @Nullable String amount,
-                @Nullable String memo, @NonNull TokenId tokenId, @Nullable String paymentId);
+                @Nullable String memo, @NonNull TokenId tokenId, @Nullable UnsignedLong paymentId);
 
         /**
          * Looks up the given <code>PaymentRequest</code> in local object storage, then returns its
@@ -832,7 +832,7 @@ public class MobileCoinFlutterPlugin implements FlutterPlugin, MethodCallHandler
 
         @Override
         public int paymentRequestCreate(int publicAddressId, @Nullable String amount,
-                @Nullable String memo, @NonNull TokenId tokenId, @Nullable String paymentId) {
+                @Nullable String memo, @NonNull TokenId tokenId, @Nullable UnsignedLong paymentId) {
             UnsignedLong unsignedAmount =
                     amount == null ? null : UnsignedLong.fromBigInteger(new BigInteger(amount));
             return FfiPaymentRequest.create(publicAddressId, unsignedAmount, memo, tokenId, paymentId);

--- a/ios/Classes/FfiPaymentRequest.swift
+++ b/ios/Classes/FfiPaymentRequest.swift
@@ -14,7 +14,7 @@ struct FfiPaymentRequest {
                       throw PluginError.invalidArguments
                   }
             let paymentIdString = args["paymentId"] as? String
-            let paymentId = UInt64(paymentIdString)
+            let paymentId = paymentIdString != nil ? UInt64(paymentIdString!) : nil
             let memo: String? = args["memo"] as? String
             let amount: String? = args["amount"] as? String
             let value: UInt64? = amount != nil ? UInt64(amount!) : nil

--- a/ios/Classes/FfiPaymentRequest.swift
+++ b/ios/Classes/FfiPaymentRequest.swift
@@ -68,14 +68,14 @@ struct FfiPaymentRequest {
             result(hashCode)
         }
     }
-    
+
     struct GetPaymentId: Command {
         func execute(args: [String : Any], result: @escaping FlutterResult) throws {
             guard let objectId: Int = args["id"] as? Int,
                   let paymentRequest = ObjectStorage.objectForKey(objectId) as? PaymentRequest else {
                       throw PluginError.invalidArguments
                   }
-            result(paymentRequest.paymentId)
+            result(paymentRequest.paymentID)
         }
     }
 }

--- a/ios/Classes/FfiPaymentRequest.swift
+++ b/ios/Classes/FfiPaymentRequest.swift
@@ -13,10 +13,12 @@ struct FfiPaymentRequest {
                   let publicAddress = ObjectStorage.objectForKey(publicAddressId) as? PublicAddress else {
                       throw PluginError.invalidArguments
                   }
+            let paymentIdString = args["paymentId"] as? String
+            let paymentId = UInt64(paymentIdString)
             let memo: String? = args["memo"] as? String
             let amount: String? = args["amount"] as? String
             let value: UInt64? = amount != nil ? UInt64(amount!) : nil
-            let paymentRequest = PaymentRequest(publicAddress: publicAddress, value:value, memo: memo, tokenID: tokenID);
+            let paymentRequest = PaymentRequest(publicAddress: publicAddress, value:value, memo: memo, tokenID: tokenID, paymentId: paymentId);
             let hashCode = paymentRequest.hashValue
             ObjectStorage.addObject(paymentRequest, forKey: hashCode)
             result(hashCode)

--- a/ios/Classes/FfiPaymentRequest.swift
+++ b/ios/Classes/FfiPaymentRequest.swift
@@ -14,7 +14,7 @@ struct FfiPaymentRequest {
                       throw PluginError.invalidArguments
                   }
             let paymentIDString = args["paymentId"] as? String
-            let paymentID = paymentIDString != nil ? UInt64(paymentIDString!) : nil
+            let paymentID: UInt64 = UInt64(paymentIDString ?? "") ?? 0
             let memo: String? = args["memo"] as? String
             let amount: String? = args["amount"] as? String
             let value: UInt64? = amount != nil ? UInt64(amount!) : nil

--- a/ios/Classes/FfiPaymentRequest.swift
+++ b/ios/Classes/FfiPaymentRequest.swift
@@ -68,5 +68,15 @@ struct FfiPaymentRequest {
             result(hashCode)
         }
     }
+    
+    struct GetPaymentId: Command {
+        func execute(args: [String : Any], result: @escaping FlutterResult) throws {
+            guard let objectId: Int = args["id"] as? Int,
+                  let paymentRequest = ObjectStorage.objectForKey(objectId) as? PaymentRequest else {
+                      throw PluginError.invalidArguments
+                  }
+            result(paymentRequest.paymentId)
+        }
+    }
 }
 

--- a/ios/Classes/FfiPaymentRequest.swift
+++ b/ios/Classes/FfiPaymentRequest.swift
@@ -13,18 +13,18 @@ struct FfiPaymentRequest {
                   let publicAddress = ObjectStorage.objectForKey(publicAddressId) as? PublicAddress else {
                       throw PluginError.invalidArguments
                   }
-            let paymentIdString = args["paymentId"] as? String
-            let paymentId = paymentIdString != nil ? UInt64(paymentIdString!) : nil
+            let paymentIDString = args["paymentId"] as? String
+            let paymentID = paymentIDString != nil ? UInt64(paymentIDString!) : nil
             let memo: String? = args["memo"] as? String
             let amount: String? = args["amount"] as? String
             let value: UInt64? = amount != nil ? UInt64(amount!) : nil
-            let paymentRequest = PaymentRequest(publicAddress: publicAddress, value:value, memo: memo, tokenID: tokenID, paymentId: paymentId);
+            let paymentRequest = PaymentRequest(publicAddress: publicAddress, value: value, memo: memo, tokenID: tokenID, paymentID: paymentID)
             let hashCode = paymentRequest.hashValue
             ObjectStorage.addObject(paymentRequest, forKey: hashCode)
             result(hashCode)
         }
     }
-    
+
     struct GetMemo: Command {
         func execute(args: [String : Any], result: @escaping FlutterResult) throws {
             guard let objectId: Int = args["id"] as? Int,

--- a/ios/Classes/FfiPaymentRequest.swift
+++ b/ios/Classes/FfiPaymentRequest.swift
@@ -25,8 +25,8 @@ struct FfiPaymentRequest {
     
     struct GetMemo: Command {
         func execute(args: [String : Any], result: @escaping FlutterResult) throws {
-            guard let paymentRequestId: Int = args["id"] as? Int,
-                  let paymentRequest = ObjectStorage.objectForKey(paymentRequestId) as? PaymentRequest else {
+            guard let objectId: Int = args["id"] as? Int,
+                  let paymentRequest = ObjectStorage.objectForKey(objectId) as? PaymentRequest else {
                       throw PluginError.invalidArguments
                   }
             result(paymentRequest.memo)
@@ -35,8 +35,8 @@ struct FfiPaymentRequest {
     
     struct GetValue: Command {
         func execute(args: [String : Any], result: @escaping FlutterResult) throws {
-            guard let paymentRequestId: Int = args["id"] as? Int,
-                  let paymentRequest = ObjectStorage.objectForKey(paymentRequestId) as? PaymentRequest else {
+            guard let objectId: Int = args["id"] as? Int,
+                  let paymentRequest = ObjectStorage.objectForKey(objectId) as? PaymentRequest else {
                       throw PluginError.invalidArguments
                   }
             result(String(paymentRequest.value ?? 0))
@@ -45,8 +45,8 @@ struct FfiPaymentRequest {
     
     struct GetTokenId: Command {
         func execute(args: [String : Any], result: @escaping FlutterResult) throws {
-            guard let paymentRequestId: Int = args["id"] as? Int,
-                  let paymentRequest = ObjectStorage.objectForKey(paymentRequestId) as? PaymentRequest else {
+            guard let objectId: Int = args["id"] as? Int,
+                  let paymentRequest = ObjectStorage.objectForKey(objectId) as? PaymentRequest else {
                       throw PluginError.invalidArguments
                   }
             result(String(paymentRequest.tokenID))
@@ -55,8 +55,8 @@ struct FfiPaymentRequest {
     
     struct GetPublicAddress: Command {
         func execute(args: [String : Any], result: @escaping FlutterResult) throws {
-            guard let paymentRequestId: Int = args["id"] as? Int,
-                  let paymentRequest = ObjectStorage.objectForKey(paymentRequestId) as? PaymentRequest else {
+            guard let objectId: Int = args["id"] as? Int,
+                  let paymentRequest = ObjectStorage.objectForKey(objectId) as? PaymentRequest else {
                       throw PluginError.invalidArguments
                   }
             let hashCode = paymentRequest.publicAddress.hashValue

--- a/ios/Classes/SwiftMobileCoinPlugin.swift
+++ b/ios/Classes/SwiftMobileCoinPlugin.swift
@@ -111,6 +111,8 @@ class CommandFactory {
             return FfiPaymentRequest.GetValue()
         case "PaymentRequest#getTokenId":
             return FfiPaymentRequest.GetTokenId()
+        case "PaymentRequest#getPaymentId":
+            return FfiPaymentRequest.GetPaymentId()
         case "PaymentRequest#getPublicAddress":
             return FfiPaymentRequest.GetPublicAddress()
         case "Mnemonic#fromBip39Entropy":

--- a/lib/src/mobilecoin_client.dart
+++ b/lib/src/mobilecoin_client.dart
@@ -43,12 +43,14 @@ class MobileCoinFlutterClient extends PlatformObject {
     required BigInt tokenId,
     String? memo,
     BigInt? amount,
+    BigInt? paymentId,
   }) =>
       MobileCoinFlutterPluginChannelApi.instance.paymentRequestCreate(
         publicAddress: publicAddress,
         tokenId: tokenId,
         memo: memo,
         amount: amount,
+        paymentId: paymentId,
       );
 
   static Future<int> printableWrapperFromPaymentRequest({

--- a/lib/src/mobilecoin_flutter_plugin_channel_api.dart
+++ b/lib/src/mobilecoin_flutter_plugin_channel_api.dart
@@ -401,6 +401,15 @@ class MobileCoinFlutterPluginChannelApi {
     return BigInt.parse(tokenIdString);
   }
 
+  Future<BigInt?> paymentRequestGetPaymentId({
+    required int objectId,
+  }) async {
+    final Map<String, dynamic> params = <String, dynamic>{
+      'id': objectId,
+    };
+    return await _channel.invokeMethod("PaymentRequest#getPaymentId", params);
+  }
+
   Future<int> paymentRequestGetPublicAddress({
     required int objectId,
   }) async {

--- a/lib/src/mobilecoin_flutter_plugin_channel_api.dart
+++ b/lib/src/mobilecoin_flutter_plugin_channel_api.dart
@@ -360,12 +360,14 @@ class MobileCoinFlutterPluginChannelApi {
     required BigInt tokenId,
     String? memo,
     BigInt? amount,
+    BigInt? paymentId,
   }) async {
     final Map<String, dynamic> params = <String, dynamic>{
       'publicAddressId': publicAddress.id,
       'memo': memo,
       'amount': amount?.toString(),
       'tokenId': tokenId.toString(),
+      'paymentId': paymentId?.toString(),
     };
     return await _channel.invokeMethod("PaymentRequest#create", params);
   }

--- a/lib/src/mobilecoin_flutter_plugin_channel_api.dart
+++ b/lib/src/mobilecoin_flutter_plugin_channel_api.dart
@@ -371,19 +371,19 @@ class MobileCoinFlutterPluginChannelApi {
   }
 
   Future<String?> paymentRequestGetMemo({
-    required int paymentRequestId,
+    required int objectId,
   }) async {
     final Map<String, dynamic> params = <String, dynamic>{
-      'id': paymentRequestId,
+      'id': objectId,
     };
     return await _channel.invokeMethod("PaymentRequest#getMemo", params);
   }
 
   Future<BigInt> paymentRequestGetValue({
-    required int paymentRequestId,
+    required int objectId,
   }) async {
     final Map<String, dynamic> params = <String, dynamic>{
-      'id': paymentRequestId,
+      'id': objectId,
     };
     String valueString =
         await _channel.invokeMethod("PaymentRequest#getValue", params);
@@ -391,10 +391,10 @@ class MobileCoinFlutterPluginChannelApi {
   }
 
   Future<BigInt> paymentRequestGetTokenId({
-    required int paymentRequestId,
+    required int objectId,
   }) async {
     final Map<String, dynamic> params = <String, dynamic>{
-      'id': paymentRequestId,
+      'id': objectId,
     };
     String tokenIdString =
         await _channel.invokeMethod("PaymentRequest#getTokenId", params);
@@ -402,10 +402,10 @@ class MobileCoinFlutterPluginChannelApi {
   }
 
   Future<int> paymentRequestGetPublicAddress({
-    required int paymentRequestId,
+    required int objectId,
   }) async {
     final Map<String, dynamic> params = <String, dynamic>{
-      'id': paymentRequestId,
+      'id': objectId,
     };
     return await _channel.invokeMethod(
       "PaymentRequest#getPublicAddress",

--- a/lib/src/payment_request.dart
+++ b/lib/src/payment_request.dart
@@ -43,4 +43,9 @@ class PaymentRequest extends PlatformObject {
     return await MobileCoinFlutterPluginChannelApi.instance
         .paymentRequestGetTokenId(objectId: id);
   }
+
+  Future<BigInt?> getPaymentId() async {
+    return await MobileCoinFlutterPluginChannelApi.instance
+        .paymentRequestGetPaymentId(objectId: id);
+  }
 }

--- a/lib/src/payment_request.dart
+++ b/lib/src/payment_request.dart
@@ -12,6 +12,7 @@ class PaymentRequest extends PlatformObject {
     required BigInt tokenId,
     String? memo,
     BigInt? amount,
+    BigInt? paymentId,
   }) async {
     final objectId =
         await MobileCoinFlutterPluginChannelApi.instance.paymentRequestCreate(
@@ -19,6 +20,7 @@ class PaymentRequest extends PlatformObject {
       memo: memo,
       amount: amount,
       tokenId: tokenId,
+      paymentId: paymentId,
     );
     return PaymentRequest(objectId);
   }

--- a/lib/src/payment_request.dart
+++ b/lib/src/payment_request.dart
@@ -25,22 +25,22 @@ class PaymentRequest extends PlatformObject {
 
   Future<PublicAddress> getPublicAddress() async {
     final objectId = await MobileCoinFlutterPluginChannelApi.instance
-        .paymentRequestGetPublicAddress(paymentRequestId: id);
+        .paymentRequestGetPublicAddress(objectId: id);
     return PublicAddress(objectId);
   }
 
   Future<BigInt> getValue() async {
     return await MobileCoinFlutterPluginChannelApi.instance
-        .paymentRequestGetValue(paymentRequestId: id);
+        .paymentRequestGetValue(objectId: id);
   }
 
   Future<String?> getMemo() async {
     return await MobileCoinFlutterPluginChannelApi.instance
-        .paymentRequestGetMemo(paymentRequestId: id);
+        .paymentRequestGetMemo(objectId: id);
   }
 
   Future<BigInt> getTokenId() async {
     return await MobileCoinFlutterPluginChannelApi.instance
-        .paymentRequestGetTokenId(paymentRequestId: id);
+        .paymentRequestGetTokenId(objectId: id);
   }
 }


### PR DESCRIPTION
The payment id param is available in the protobufs for PaymentRequest and was previously included in the ios sdk. [This PR](https://github.com/mobilecoinofficial/android-sdk/pull/152) includes it in the android sdk in version 6.1.3. 

The purpose of this PR is to include payment_id parameters in dart with the accompanying native ios and android wirings. To avoid naming confusion, I changed the `paymentRequestId`, which refers to the object id, to `objectId`.