### PR TITLE
Add payment id method handler to java

### DIFF
--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
@@ -528,6 +528,12 @@ public class MobileCoinFlutterPlugin implements FlutterPlugin, MethodCallHandler
         String paymentRequestGetTokenId(int paymentRequestId);
 
         /**
+         * Looks up the given <code>PaymentRequest</code> in local object storage, then returns its
+         * payment id as a <code>String</code>.
+         */
+        String paymentRequestGetPaymentId(int paymentRequestId);
+
+        /**
          * Looks up the given <code>PaymentRequest</code> in local object storage, then retrieves
          * its public address, stores that public address in local object storage, and then returns
          * the public address' hash code.

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
@@ -866,6 +866,11 @@ public class MobileCoinFlutterPlugin implements FlutterPlugin, MethodCallHandler
         }
 
         @Override
+        public String paymentRequestGetPaymentId(int paymentRequestId) {
+            return FfiPaymentRequest.getPaymentId(paymentRequestId);
+        }
+
+        @Override
         public int paymentRequestGetPublicAddress(int paymentRequestId) {
             return FfiPaymentRequest.getPublicAddress(paymentRequestId);
         }

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/MobileCoinFlutterPlugin.java
@@ -258,6 +258,8 @@ public class MobileCoinFlutterPlugin implements FlutterPlugin, MethodCallHandler
                 return api.paymentRequestGetPublicAddress(getCallArgument(call, "id"));
             case "PaymentRequest#getTokenId":
                 return api.paymentRequestGetTokenId(getCallArgument(call, "id"));
+            case "PaymentRequest#getPaymentId":
+                return api.paymentRequestGetPaymentId(getCallArgument(call, "id"));
             case "PaymentRequest#getValue":
                 return api.paymentRequestGetValue(getCallArgument(call, "id"));
             case "Mnemonic#fromBip39Entropy":


### PR DESCRIPTION
Adds missing method channel handling for `PaymentRequest#getPaymentId` on Android