### PR TITLE
Return receipt id with pending transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.2
+
+## Breaking Changes
+
+- `receiptId` is no longer being returned from `sendFunds`. It has been moved to the response from `createPendingTransaction`
+
 ## 0.0.1
 
 * Initial open source release.

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiMobileCoinClient.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiMobileCoinClient.java
@@ -342,8 +342,8 @@ public class FfiMobileCoinClient {
         final PendingTransaction pendingTransaction = mobileCoinClient.prepareTransaction(recipient,
                 new Amount(amount.getPicoCountAsBigInt(), tokenId),
                 new Amount(fee.getPicoCountAsBigInt(), tokenId), txOutMemoBuilder, rng);
-        final transaction = pendingTransaction.getTransaction();
-        final receiptId = transaction.hashCode();
+        final Transaction transaction = pendingTransaction.getTransaction();
+        final int receiptId = transaction.hashCode();
         ObjectStorage.addObject(receiptId, transaction);
 
         HashMap<String, Object> returnPayload = new HashMap<>();

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiMobileCoinClient.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiMobileCoinClient.java
@@ -342,9 +342,13 @@ public class FfiMobileCoinClient {
         final PendingTransaction pendingTransaction = mobileCoinClient.prepareTransaction(recipient,
                 new Amount(amount.getPicoCountAsBigInt(), tokenId),
                 new Amount(fee.getPicoCountAsBigInt(), tokenId), txOutMemoBuilder, rng);
+        final transaction = pendingTransaction.getTransaction();
+        final receiptId = transaction.hashCode();
+        ObjectStorage.addObject(receiptId, transaction);
 
         HashMap<String, Object> returnPayload = new HashMap<>();
-        returnPayload.put("transaction", pendingTransaction.getTransaction().toByteArray());
+        returnPayload.put("transaction", transaction.toByteArray());
+        returnPayload.put("receiptId", receiptId);
 
         final RistrettoPublic payloadTxOutPublicKey =
                 pendingTransaction.getPayloadTxOutContext().getTxOutPublicKey();
@@ -372,9 +376,6 @@ public class FfiMobileCoinClient {
         MobileCoinClient mobileCoinClient =
                 (MobileCoinClient) ObjectStorage.objectForKey(mobileClientId);
         Transaction transaction = Transaction.fromBytes(serializedTransaction);
-        int receiptId = transaction.hashCode();
-
-        ObjectStorage.addObject(receiptId, transaction);
 
         JSONObject resultObject = new JSONObject();
 
@@ -383,7 +384,6 @@ public class FfiMobileCoinClient {
 
             resultObject.put("status", "OK");
             resultObject.put("blockIndex", blockIndex);
-            resultObject.put("receiptId", receiptId);
         } catch (InvalidTransactionException e) {
             final ConsensusCommon.ProposeTxResult result =
                     e.getResult() == null ? ConsensusCommon.ProposeTxResult.UNRECOGNIZED

--- a/ios/Classes/FFiMobileCoinClient.swift
+++ b/ios/Classes/FFiMobileCoinClient.swift
@@ -481,7 +481,12 @@ struct FfiMobileCoinClient {
                 case .success(let (pending)):
                     var returnPayload: [String: Any] = [:]
 
-                    returnPayload["transaction"] = FlutterStandardTypedData(bytes: pending.transaction.serializedData)
+                    let transaction = pending.transaction
+                    let receiptId = transaction.hashValue
+                    ObjectStorage.addObject(transaction, forKey: receiptId);
+
+                    returnPayload["transaction"] = FlutterStandardTypedData(bytes: transaction.serializedData)
+                    returnPayload["receiptId"] = receiptId
 
                     let payloadTxOutPublicKey = pending.payloadTxOutContext.txOutPublicKey
                     let payloadTxOutSharedSecret = pending.payloadTxOutContext.sharedSecretBytes
@@ -519,10 +524,6 @@ struct FfiMobileCoinClient {
                     throw PluginError.invalidArguments
                 }
 
-            let receiptId = transaction.hashValue
-
-            ObjectStorage.addObject(transaction, forKey: receiptId);
-
             mobileCoinClient.submitTransaction(transaction: transaction) { (txResult: Result<(UInt64), SubmitTransactionError>) in
                 var jsonObject: [String: Any] = [:]
                 do {
@@ -530,7 +531,6 @@ struct FfiMobileCoinClient {
                     case .success(let blockIndex):
                         jsonObject["status"] = "OK"
                         jsonObject["blockIndex"] = blockIndex
-                        jsonObject["receiptId"] = receiptId
                     case .failure(let error):
                         switch error.submissionError {
                         case .connectionError:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mobilecoin_flutter
 description: Flutter plugin providing Dart bindings for MobileCoin-Swift and android-sdk.
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/mobilecoinofficial/mobilecoin_flutter_plugin
 
 environment:


### PR DESCRIPTION
The `receiptId` is currently being returned after sending funds, but because it is just the hashCode of the transaction object, it can be returned once the pending transaction is assembled.

Object storage is also being updated to assign the transaction to the receiptId earlier.