### PR TITLE
avoid null check operator error

### DIFF
--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
@@ -51,6 +51,7 @@ public class FfiPaymentRequest {
     }
 
     public static String getPaymentId(int requestId) {
+        PaymentRequest paymentRequest = (PaymentRequest) ObjectStorage.objectForKey(requestId);
         UnsignedLong paymentId = paymentRequest.getPaymentId();
         return paymentId != null ? paymentId.toString() : "0";
     }

--- a/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
+++ b/android/src/main/java/com/mobilecoin/mobilecoin_flutter/FfiPaymentRequest.java
@@ -51,7 +51,7 @@ public class FfiPaymentRequest {
     }
 
     public static String getPaymentId(int requestId) {
-        PaymentRequest paymentRequest = (PaymentRequest) ObjectStorage.objectForKey(requestId);
-        return paymentRequest.getPaymentId().toString();
+        UnsignedLong paymentId = paymentRequest.getPaymentId();
+        return paymentId != null ? paymentId.toString() : "0";
     }
 }


### PR DESCRIPTION
This fixes a `NullPointerException` in the Android FFI layer when calling paymentRequest.getPaymentId().toString(). `PaymentRequest.getPaymentId()` can return null, but the code was attempting to call .toString() on the null object. It returns a "0" as default now to match the iOS behavoir.